### PR TITLE
7716: Properly exclude all Apache Http Client dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,10 @@
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpcore</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
             </exclusions>            
         </dependency>
         <!-- Testing -->


### PR DESCRIPTION
http://jira.abiquo.com/browse/ABICLOUDPREMIUM-7716

The Apache Http Client version used by Thrift conflicts with the one required by the AWS SDK in the Amazon plugin. Since we don't use the HTTP transport in the AIM client, it is safe to exclude the dependency.

/cc @enricruiz 